### PR TITLE
Example launch file for init_yaw_from_compass

### DIFF
--- a/msf_updates/launch/init_yaw_from_compass.launch
+++ b/msf_updates/launch/init_yaw_from_compass.launch
@@ -1,0 +1,13 @@
+<launch>
+
+  <node pkg="msf_updates" type="init_yaw_from_compass.py" name="init_yaw" clear_params="true" output="screen">
+    <!-- Specify name of node running MSF -->
+    <param name="msf_sensor_node" type="string" value="msf_gps_pose_estimator/position_sensor" />
+
+    <!-- Specify topic to obtain heading from (use one) -->
+    <!-- remap from="orientation_quaternion" to="/fcu/imu/orientation" / -->
+    <!-- remap from="orientation_degrees" to="/orientation_euler_estimated_odometry_degrees" / -->
+    <remap from="heading_radians" to="heading" />
+  </node>
+
+</launch>


### PR DESCRIPTION
I've added a commented launch file showing an example of how to start the init_yaw_from_compass node. This change is in a seperate pull request because the src file was merged to master yesterday.