### PR TITLE
Fix/cmake

### DIFF
--- a/msf_core/CMakeLists.txt
+++ b/msf_core/CMakeLists.txt
@@ -57,9 +57,22 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg) # ${MSF_DOCUMENTATION})
 add_library(similaritytransform src/similaritytransform.cc)
 target_link_libraries(similaritytransform ${catkin_LIBRARIES})
 
-catkin_add_gtest(test_similaritytransform src/test/test_similaritytransform.cc)
-target_link_libraries(test_similaritytransform similaritytransform)
+install(TARGETS
+    ${PROJECT_NAME}
+    similaritytransform
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
 
-catkin_add_gtest(test_static_statelist src/test/test_staticstatelist.cc)
-target_link_libraries(test_static_statelist pthread ${PROJECT_NAME})
+install(DIRECTORY include/
+    DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+    FILES_MATCHING PATTERN "*.h"
+)
 
+if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(test_similaritytransform src/test/test_similaritytransform.cc)
+    target_link_libraries(test_similaritytransform similaritytransform)
+
+    catkin_add_gtest(test_static_statelist src/test/test_staticstatelist.cc)
+    target_link_libraries(test_static_statelist pthread ${PROJECT_NAME})
+endif()

--- a/msf_distort/CMakeLists.txt
+++ b/msf_distort/CMakeLists.txt
@@ -26,3 +26,8 @@ add_executable(msf_distort src/msf_distort.cc)
 target_link_libraries(msf_distort ${catkin_LIBRARIES} ${boost_LIBRARIES})
 add_dependencies(msf_distort ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
+install(TARGETS
+    msf_distort
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)

--- a/msf_timing/CMakeLists.txt
+++ b/msf_timing/CMakeLists.txt
@@ -29,7 +29,20 @@ catkin_package(
 
 add_library(${PROJECT_NAME} src/Timer.cc)
 
-catkin_add_gtest(${PROJECT_NAME}_tests src/test/testMSFTiming.cc)
-target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME} pthread)
+install(TARGETS
+    ${PROJECT_NAME}
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+)
+
+if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(${PROJECT_NAME}_tests src/test/testMSFTiming.cc)
+    target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME} pthread)
+endif()
 
 

--- a/msf_updates/CMakeLists.txt
+++ b/msf_updates/CMakeLists.txt
@@ -30,6 +30,11 @@ catkin_package(
 
 add_library(pose_distorter src/msf_distort/PoseDistorter.cc)
 target_link_libraries(pose_distorter ${catkin_LIBRARIES})
+install(TARGETS
+    pose_distorter
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
 
 #just build the pose filter on the helicopters
 if(EXISTS "${PROJECT_SOURCE_DIR}/COMPILE_ONLY_POSEFILTER")

--- a/msf_updates/src/pose_msf/CMakeLists.txt
+++ b/msf_updates/src/pose_msf/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable(pose_sensor main.cpp)
 target_link_libraries(pose_sensor pose_distorter ${catkin_LIBRARIES})
 
 add_dependencies(pose_sensor ${${PROJECT_NAME}_EXPORTED_TARGETS})
+
+install(TARGETS
+    pose_sensor
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)


### PR DESCRIPTION
With these changes I can run roslaunch rotors_simulator_demos mav_hovering_example_msf.launch.
To compile the project I've used catkin_make_isolated --install.
