### PR TITLE
Devel/outlier check

### DIFF
--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -58,11 +58,11 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
     //calculate mahalanobis distance
     double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
     mah_dist = sqrt(mah_dist);
-    MSF_INFO_STREAM(mah_dist);
+    MSF_INFO_STREAM(mah_dist << " " << mah_threshold_);
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){
-      MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
+      MSF_WARN_STREAME("rejecting reading as outlier");
       return;
     }
   }

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -62,6 +62,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){
+      MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
       return;
     }
   }
@@ -104,6 +105,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){
+      MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
       return;
     }
   }

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -50,6 +50,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
+  std::cerr << res_delayed << std::endl;
+  std::cerr << S << std::endl;
+
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =
       (MSF_Core<EKFState_T>::ErrorStateCov::Identity() - K * H_delayed);
@@ -79,6 +82,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
+
+  std::cerr << res_delayed << std::endl;
+  std::cerr << S << std::endl;
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -96,6 +96,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   typename MSF_Core<EKFState_T>::ErrorStateCov & P = state->P;
 
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
+  S_inverse = S.inverse();
   K = P * H_delayed.transpose() * S_inverse;
 
   if(enable_mah_outlier_rejection_){

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -50,9 +50,10 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
+  double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
+  mah_dist = sqrt(mah_dist);
   MSF_INFO_STREAM("RUN 1");
-  MSF_INFO_STREAM(res_delayed);
-  MSF_INFO_STREAM(S);
+  MSF_INFO_STREAM(mah_dist);
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -112,6 +112,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrectionRelative(
   EIGEN_STATIC_ASSERT_FIXED_SIZE (R_type);
 
   MSF_INFO_STREAM("RUN 3");
+  int a = 1;
 
   // Get measurements.
   /// Correction from EKF update.

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -186,6 +186,7 @@ void MSF_InitMeasurement<EKFState_T>::Apply(
   boost::fusion::for_each(stateWithCovariance->statevars,
                           msf_tmp::CopyInitStates<EKFState_T>(InitState));
 
+  MSF_INFO_STREAM("TESTING");
   if (!(InitState.P.minCoeff() == 0 && InitState.P.maxCoeff() == 0)) {
     stateWithCovariance->P = InitState.P;
     MSF_WARN_STREAM("Using user defined initial error state covariance.");

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -62,7 +62,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){
-      MSF_WARN_STREAM("rejecting reading as outlier");
+      MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
       return;
     }
   }
@@ -101,7 +101,6 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
     //calculate mahalanobis distance
     double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
     mah_dist = sqrt(mah_dist);
-    MSF_INFO_STREAM(mah_dist);
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -203,7 +203,6 @@ void MSF_InitMeasurement<EKFState_T>::Apply(
   boost::fusion::for_each(stateWithCovariance->statevars,
                           msf_tmp::CopyInitStates<EKFState_T>(InitState));
 
-  MSF_INFO_STREAM("TESTING");
   if (!(InitState.P.minCoeff() == 0 && InitState.P.maxCoeff() == 0)) {
     stateWithCovariance->P = InitState.P;
     MSF_WARN_STREAM("Using user defined initial error state covariance.");

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -17,7 +17,6 @@
 #ifndef MEASUREMENT_INL_H_
 #define MEASUREMENT_INL_H_
 #include <msf_core/msf_core.h>
- #include <ros/console.h>
 
 namespace msf_core {
 template<typename EKFState_T>
@@ -111,6 +110,8 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrectionRelative(
 
   EIGEN_STATIC_ASSERT_FIXED_SIZE (H_type);
   EIGEN_STATIC_ASSERT_FIXED_SIZE (R_type);
+
+  MSF_INFO_STREAM("RUN 3");
 
   // Get measurements.
   /// Correction from EKF update.

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -51,9 +51,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
-  ROS_ERROR_STREAM("RUN 1");
-  ROS_ERROR_STREAM(res_delayed);
-  ROS_ERROR_STREAM(S);
+  MSF_INFO_STREAM("RUN 1");
+  MSF_INFO_STREAM(res_delayed);
+  MSF_INFO_STREAM(S);
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =
@@ -85,9 +85,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
-  ROS_ERROR_STREAM("RUN 2");
-  ROS_ERROR_STREAM(res_delayed);
-  ROS_ERROR_STREAM(S);
+  MSF_INFO_STREAM("RUN 2");
+  MSF_INFO_STREAM(res_delayed);
+  MSF_INFO_STREAM(S);
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -58,7 +58,6 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
     //calculate mahalanobis distance
     double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
     mah_dist = sqrt(mah_dist);
-    MSF_INFO_STREAM(mah_dist << " " << mah_threshold_);
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -62,7 +62,7 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
     //reject point as outlier if distance above threshold
     if (mah_dist > mah_threshold_){
-      MSF_WARN_STREAME("rejecting reading as outlier");
+      MSF_WARN_STREAM("rejecting reading as outlier");
       return;
     }
   }

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -47,20 +47,21 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   Eigen::Matrix<double, MSF_Core<EKFState_T>::nErrorStatesAtCompileTime, 1> correction_;
 
   R_type S;
+  R_type S_inverse;
   Eigen::Matrix<double, MSF_Core<EKFState_T>::nErrorStatesAtCompileTime,
       R_type::RowsAtCompileTime> K;
   typename MSF_Core<EKFState_T>::ErrorStateCov & P = state->P;
 
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
-  K = P * H_delayed.transpose() * S.inverse();
+  S_inverse = S.inverse();
+  K = P * H_delayed.transpose() * S_inverse;
 
   if(enable_mah_outlier_rejection_){
     //calculate mahalanobis distance
-    double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
-    mah_dist = sqrt(mah_dist);
+    double mah_dist_squared = res_delayed.transpose() * S_inverse * res_delayed;
 
     //reject point as outlier if distance above threshold
-    if (mah_dist > mah_threshold_){
+    if (sqrt(mah_dist_squared) > mah_threshold_){
       MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
       return;
     }
@@ -88,21 +89,21 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   Eigen::Matrix<double, MSF_Core<EKFState_T>::nErrorStatesAtCompileTime, 1> correction_;
 
   Eigen::MatrixXd S;
+  Eigen::MatrixXd S_inverse;
   Eigen::MatrixXd K(
       static_cast<int>(MSF_Core<EKFState_T>::nErrorStatesAtCompileTime),
       R_delayed.rows());
   typename MSF_Core<EKFState_T>::ErrorStateCov & P = state->P;
 
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
-  K = P * H_delayed.transpose() * S.inverse();
+  K = P * H_delayed.transpose() * S_inverse;
 
   if(enable_mah_outlier_rejection_){
     //calculate mahalanobis distance
-    double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
-    mah_dist = sqrt(mah_dist);
+    double mah_dist_squared = res_delayed.transpose() * S_inverse * res_delayed;
 
     //reject point as outlier if distance above threshold
-    if (mah_dist > mah_threshold_){
+    if (sqrt(mah_dist_squared) > mah_threshold_){
       MSF_WARN_STREAM_THROTTLE(1,"rejecting reading as outlier");
       return;
     }

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -17,6 +17,7 @@
 #ifndef MEASUREMENT_INL_H_
 #define MEASUREMENT_INL_H_
 #include <msf_core/msf_core.h>
+ #include <ros/console.h>
 
 namespace msf_core {
 template<typename EKFState_T>
@@ -50,8 +51,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
-  std::cerr << res_delayed << std::endl;
-  std::cerr << S << std::endl;
+  ROS_ERROR_STREAM("RUN 1");
+  ROS_ERROR_STREAM(res_delayed);
+  ROS_ERROR_STREAM(S);
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =
@@ -83,8 +85,9 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
   S = H_delayed * P * H_delayed.transpose() + R_delayed;
   K = P * H_delayed.transpose() * S.inverse();
 
-  std::cerr << res_delayed << std::endl;
-  std::cerr << S << std::endl;
+  ROS_ERROR_STREAM("RUN 2");
+  ROS_ERROR_STREAM(res_delayed);
+  ROS_ERROR_STREAM(S);
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =

--- a/msf_core/include/msf_core/implementation/msf_measurement_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_measurement_inl.h
@@ -52,8 +52,11 @@ void MSF_MeasurementBase<EKFState_T>::CalculateAndApplyCorrection(
 
   double mah_dist = res_delayed.transpose() * S.inverse() * res_delayed;
   mah_dist = sqrt(mah_dist);
-  MSF_INFO_STREAM("RUN 1");
   MSF_INFO_STREAM(mah_dist);
+
+  if (mah_dist > 10){
+    return;
+  }
 
   correction_ = K * res_delayed;
   const typename MSF_Core<EKFState_T>::ErrorStateCov KH =

--- a/msf_core/include/msf_core/msf_measurement.h
+++ b/msf_core/include/msf_core/msf_measurement.h
@@ -127,7 +127,7 @@ class MSF_Measurement : public MSF_MeasurementBase<EKFState_T> {
                   bool enable_mah_outlier_rejection, double mah_threshold)
       : MSF_MeasurementBase<EKFState_T>(isAbsoluteMeasurement, sensorID,
                                         enable_mah_outlier_rejection,
-                                        mah_threshold) {
+                                        7) {
     R_.setZero();
   }
   virtual ~MSF_Measurement() { }

--- a/msf_core/include/msf_core/msf_measurement.h
+++ b/msf_core/include/msf_core/msf_measurement.h
@@ -73,7 +73,7 @@ class MSF_MeasurementBase {
       const Eigen::MatrixBase<Res_type>& residual,
       const Eigen::MatrixBase<R_type>& R);
 
-  /// Enabels mahalanobis distance outlier rejection
+  /// Enables mahalanobis distance outlier rejection
   bool enable_mah_outlier_rejection_;
 
   /// Mahalanobis distance outlier rejection threshold

--- a/msf_core/include/msf_core/msf_measurement.h
+++ b/msf_core/include/msf_core/msf_measurement.h
@@ -33,9 +33,10 @@ template<typename EKFState_T>
 class MSF_MeasurementBase {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  MSF_MeasurementBase(bool isabsoluteMeasurement, int sensorID);
-  virtual ~MSF_MeasurementBase() {
-  }
+  MSF_MeasurementBase(bool isabsoluteMeasurement, int sensorID,
+                      bool enable_mah_outlier_rejection,
+                      double mah_threshold);
+  virtual ~MSF_MeasurementBase() {}
   /**
    * \brief The method called by the msf_core to apply the measurement
    * represented by this object.
@@ -72,6 +73,12 @@ class MSF_MeasurementBase {
       const Eigen::MatrixBase<Res_type>& residual,
       const Eigen::MatrixBase<R_type>& R);
 
+  /// Enabels mahalanobis distance outlier rejection
+  bool enable_mah_outlier_rejection_;
+
+  /// Mahalanobis distance outlier rejection threshold
+  double mah_threshold_;
+
 };
 
 /**
@@ -92,7 +99,7 @@ class MSF_InvalidMeasurement : public MSF_MeasurementBase<EKFState_T> {
     return "invalid";
   }
   MSF_InvalidMeasurement()
-      : MSF_MeasurementBase<EKFState_T>(true, constants::INVALID_ID) {
+      : MSF_MeasurementBase<EKFState_T>(true, constants::INVALID_ID, false, 0.0) {
   }
   virtual ~MSF_InvalidMeasurement() {
   }
@@ -116,8 +123,11 @@ class MSF_Measurement : public MSF_MeasurementBase<EKFState_T> {
   typedef T Measurement_type;
   typedef boost::shared_ptr<T const> Measurement_ptr;
 
-  MSF_Measurement(bool isAbsoluteMeasurement, int sensorID)
-      : MSF_MeasurementBase<EKFState_T>(isAbsoluteMeasurement, sensorID) {
+  MSF_Measurement(bool isAbsoluteMeasurement, int sensorID,
+                  bool enable_mah_outlier_rejection, double mah_threshold)
+      : MSF_MeasurementBase<EKFState_T>(isAbsoluteMeasurement, sensorID,
+                                        enable_mah_outlier_rejection,
+                                        mah_threshold) {
     R_.setZero();
   }
   virtual ~MSF_Measurement() { }
@@ -161,7 +171,7 @@ class MSF_InitMeasurement : public MSF_MeasurementBase<EKFState_T> {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW MSF_InitMeasurement(
       bool ContainsInitialSensorReadings)
-      : MSF_MeasurementBase<EKFState_T>(true, constants::INVALID_ID) {
+      : MSF_MeasurementBase<EKFState_T>(true, constants::INVALID_ID, false, 0.0) {
     ContainsInitialSensorReadings_ = ContainsInitialSensorReadings;
     this->time = ros::Time::now().toSec();
   }

--- a/msf_core/include/msf_core/msf_measurement.h
+++ b/msf_core/include/msf_core/msf_measurement.h
@@ -127,7 +127,7 @@ class MSF_Measurement : public MSF_MeasurementBase<EKFState_T> {
                   bool enable_mah_outlier_rejection, double mah_threshold)
       : MSF_MeasurementBase<EKFState_T>(isAbsoluteMeasurement, sensorID,
                                         enable_mah_outlier_rejection,
-                                        7) {
+                                        mah_threshold) {
     R_.setZero();
   }
   virtual ~MSF_Measurement() { }

--- a/msf_core/include/msf_core/msf_sensorhandler.h
+++ b/msf_core/include/msf_core/msf_sensorhandler.h
@@ -18,6 +18,8 @@
 #define MSF_SENSORHANDLER_H_
 
 namespace msf_core {
+
+  static constexpr double kDefaultMahThreshold_ = 100.0;
 /**
  * \class SensorHandler
  * \brief Handles a sensor driver which provides the sensor readings.
@@ -34,7 +36,6 @@ class SensorHandler {
   bool received_first_measurement_;
   bool enable_mah_outlier_rejection_;
   double mah_threshold_;
-  const double default_mah_threshold_ = 100.0;
 
   void SetSensorID(int ID) {
     sensorID = ID;

--- a/msf_core/include/msf_core/msf_sensorhandler.h
+++ b/msf_core/include/msf_core/msf_sensorhandler.h
@@ -32,6 +32,10 @@ class SensorHandler {
   std::string topic_namespace_;
   std::string parameternamespace_;
   bool received_first_measurement_;
+  bool enable_mah_outlier_rejection_;
+  double mah_threshold_;
+  const double default_mah_threshold_ = 100.0;
+
   void SetSensorID(int ID) {
     sensorID = ID;
   }

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -45,7 +45,7 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   pnh.param("pose_use_fixed_covariance", use_fixed_covariance_, false);
   pnh.param("pose_measurement_minimum_dt", pose_measurement_minimum_dt_, 0.05);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
-  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+  pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
   MSF_INFO_STREAM_COND(measurement_world_sensor_, "Pose sensor is interpreting "
                        "measurement as sensor w.r.t. world");

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -162,8 +162,6 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPoseMeasurement(
     }
   }
 
-  MSF_INFO_STREAM(mah_threshold_ << " input value !!!!!!!!!!!!!!!!!!!!!");
-
   shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
       n_zp_, n_zq_, measurement_world_sensor_, use_fixed_covariance_,
       provides_absolute_measurements_, this->sensorID,

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -44,6 +44,8 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   pnh.param("pose_measurement_world_sensor", measurement_world_sensor_, true);
   pnh.param("pose_use_fixed_covariance", use_fixed_covariance_, false);
   pnh.param("pose_measurement_minimum_dt", pose_measurement_minimum_dt_, 0.05);
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
 
   MSF_INFO_STREAM_COND(measurement_world_sensor_, "Pose sensor is interpreting "
@@ -158,12 +160,10 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPoseMeasurement(
     }
   }
 
-  shared_ptr < MEASUREMENT_TYPE
-      > meas(
-          new MEASUREMENT_TYPE(n_zp_, n_zq_, measurement_world_sensor_,
-                               use_fixed_covariance_,
-                               provides_absolute_measurements_, this->sensorID,
-                               fixedstates, distorter_));
+  shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
+      n_zp_, n_zq_, measurement_world_sensor_, use_fixed_covariance_,
+      provides_absolute_measurements_, this->sensorID,
+      enable_mah_outlier_rejection_, mah_threshold_, fixedstates, distorter_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -47,6 +47,8 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
+  MSF_INFO_STREAM(mah_threshold_ << " !!!!!!!!!!!!!!!!!!!!!")
+
 
   MSF_INFO_STREAM_COND(measurement_world_sensor_, "Pose sensor is interpreting "
                        "measurement as sensor w.r.t. world");

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -162,6 +162,8 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPoseMeasurement(
     }
   }
 
+  MSF_INFO_STREAM(mah_threshold_ << " input value !!!!!!!!!!!!!!!!!!!!!");
+
   shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
       n_zp_, n_zq_, measurement_world_sensor_, use_fixed_covariance_,
       provides_absolute_measurements_, this->sensorID,

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -163,7 +163,7 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPoseMeasurement(
   shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
       n_zp_, n_zq_, measurement_world_sensor_, use_fixed_covariance_,
       provides_absolute_measurements_, this->sensorID,
-      enable_mah_outlier_rejection_, 7, fixedstates, distorter_));
+      enable_mah_outlier_rejection_, mah_threshold_, fixedstates, distorter_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -163,7 +163,7 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPoseMeasurement(
   shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
       n_zp_, n_zq_, measurement_world_sensor_, use_fixed_covariance_,
       provides_absolute_measurements_, this->sensorID,
-      enable_mah_outlier_rejection_, mah_threshold_, fixedstates, distorter_));
+      enable_mah_outlier_rejection_, 7, fixedstates, distorter_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -47,7 +47,7 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
-  MSF_INFO_STREAM(mah_threshold_ << " !!!!!!!!!!!!!!!!!!!!!")
+  MSF_INFO_STREAM(mah_threshold_ << " !!!!!!!!!!!!!!!!!!!!!");
 
 
   MSF_INFO_STREAM_COND(measurement_world_sensor_, "Pose sensor is interpreting "

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -47,9 +47,6 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
-  MSF_INFO_STREAM(mah_threshold_ << " !!!!!!!!!!!!!!!!!!!!!");
-
-
   MSF_INFO_STREAM_COND(measurement_world_sensor_, "Pose sensor is interpreting "
                        "measurement as sensor w.r.t. world");
   MSF_INFO_STREAM_COND(

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -140,16 +140,17 @@ struct PoseMeasurement : public PoseMeasurementBase {
   PoseMeasurement(double n_zp, double n_zq, bool measurement_world_sensor,
                   bool fixed_covariance, bool isabsoluteMeasurement,
                   int sensorID, int fixedstates,
+                  bool enable_mah_outlier_rejection, double mah_threshold,
                   msf_updates::PoseDistorter::Ptr distorter =
                       msf_updates::PoseDistorter::Ptr())
-      : PoseMeasurementBase(isabsoluteMeasurement, sensorID),
+      : PoseMeasurementBase(isabsoluteMeasurement, sensorID,
+                            enable_mah_outlier_rejection, mah_threshold),
         n_zp_(n_zp),
         n_zq_(n_zq),
         measurement_world_sensor_(measurement_world_sensor),
         fixed_covariance_(fixed_covariance),
         distorter_(distorter),
-        fixedstates_(fixedstates) {
-  }
+        fixedstates_(fixedstates) {}
   virtual std::string Type() {
     return "pose";
   }

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -150,7 +150,10 @@ struct PoseMeasurement : public PoseMeasurementBase {
         measurement_world_sensor_(measurement_world_sensor),
         fixed_covariance_(fixed_covariance),
         distorter_(distorter),
-        fixedstates_(fixedstates) {}
+        fixedstates_(fixedstates) {
+            MSF_INFO_STREAM(mah_threshold << " output value !!!!!!!!!!!!!!!!!!!!!");
+            MSF_INFO_STREAM(mah_threshold_ << " output real value !!!!!!!!!!!!!!!!!!!!!");
+        }
   virtual std::string Type() {
     return "pose";
   }

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -144,7 +144,7 @@ struct PoseMeasurement : public PoseMeasurementBase {
                   msf_updates::PoseDistorter::Ptr distorter =
                       msf_updates::PoseDistorter::Ptr())
       : PoseMeasurementBase(isabsoluteMeasurement, sensorID,
-                            enable_mah_outlier_rejection, mah_threshold),
+                            enable_mah_outlier_rejection, 7),
         n_zp_(n_zp),
         n_zq_(n_zq),
         measurement_world_sensor_(measurement_world_sensor),

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -149,10 +149,7 @@ struct PoseMeasurement : public PoseMeasurementBase {
         measurement_world_sensor_(measurement_world_sensor),
         fixed_covariance_(fixed_covariance),
         distorter_(distorter),
-        fixedstates_(fixedstates) {
-            MSF_INFO_STREAM(mah_threshold << " output value !!!!!!!!!!!!!!!!!!!!!");
-            MSF_INFO_STREAM(mah_threshold_ << " output2 value !!!!!!!!!!!!!!!!!!!!!");
-        }
+        fixedstates_(fixedstates) {}
   virtual std::string Type() {
     return "pose";
   }

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -144,7 +144,7 @@ struct PoseMeasurement : public PoseMeasurementBase {
                   msf_updates::PoseDistorter::Ptr distorter =
                       msf_updates::PoseDistorter::Ptr())
       : PoseMeasurementBase(isabsoluteMeasurement, sensorID,
-                            enable_mah_outlier_rejection, 7),
+                            enable_mah_outlier_rejection, mah_threshold),
         n_zp_(n_zp),
         n_zq_(n_zq),
         measurement_world_sensor_(measurement_world_sensor),

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_measurement.h
@@ -135,12 +135,11 @@ struct PoseMeasurement : public PoseMeasurementBase {
     p_wv = StatePwvIdx
   };
 
-  virtual ~PoseMeasurement() {
-  }
+  virtual ~PoseMeasurement() {}
   PoseMeasurement(double n_zp, double n_zq, bool measurement_world_sensor,
                   bool fixed_covariance, bool isabsoluteMeasurement,
-                  int sensorID, int fixedstates,
-                  bool enable_mah_outlier_rejection, double mah_threshold,
+                  int sensorID, bool enable_mah_outlier_rejection,
+                  double mah_threshold, int fixedstates,
                   msf_updates::PoseDistorter::Ptr distorter =
                       msf_updates::PoseDistorter::Ptr())
       : PoseMeasurementBase(isabsoluteMeasurement, sensorID,
@@ -152,7 +151,7 @@ struct PoseMeasurement : public PoseMeasurementBase {
         distorter_(distorter),
         fixedstates_(fixedstates) {
             MSF_INFO_STREAM(mah_threshold << " output value !!!!!!!!!!!!!!!!!!!!!");
-            MSF_INFO_STREAM(mah_threshold_ << " output real value !!!!!!!!!!!!!!!!!!!!!");
+            MSF_INFO_STREAM(mah_threshold_ << " output2 value !!!!!!!!!!!!!!!!!!!!!");
         }
   virtual std::string Type() {
     return "pose";

--- a/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
@@ -35,6 +35,8 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
   pnh.param("position_use_fixed_covariance", use_fixed_covariance_, false);
   pnh.param("position_absolute_measurements", provides_absolute_measurements_,
             false);
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
   MSF_INFO_STREAM_COND(use_fixed_covariance_, "Position sensor is using fixed "
                        "covariance");
@@ -109,11 +111,10 @@ void PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::ProcessPositionMeasu
     }
   }
 
-  shared_ptr < MEASUREMENT_TYPE
-      > meas(
-          new MEASUREMENT_TYPE(n_zp_, use_fixed_covariance_,
-                               provides_absolute_measurements_, this->sensorID,
-                               fixedstates));
+  shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
+      n_zp_, use_fixed_covariance_, provides_absolute_measurements_,
+      this->sensorID, fixedstates, enable_mah_outlier_rejection_,
+      mah_threshold_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 

--- a/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
@@ -36,7 +36,7 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
   pnh.param("position_absolute_measurements", provides_absolute_measurements_,
             false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
-  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+  pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
   MSF_INFO_STREAM_COND(use_fixed_covariance_, "Position sensor is using fixed "
                        "covariance");

--- a/msf_updates/include/msf_updates/position_sensor_handler/position_measurement.h
+++ b/msf_updates/include/msf_updates/position_sensor_handler/position_measurement.h
@@ -86,8 +86,10 @@ struct PositionMeasurement : public PositionMeasurementBase {
   virtual ~PositionMeasurement() {
   }
   PositionMeasurement(double n_zp, bool fixed_covariance,
-                      bool isabsoluteMeasurement, int sensorID, int fixedstates)
-      : PositionMeasurementBase(isabsoluteMeasurement, sensorID),
+                      bool isabsoluteMeasurement, int sensorID, int fixedstates,
+                      bool enable_mah_outlier_rejection, double mah_threshold)
+      : PositionMeasurementBase(isabsoluteMeasurement, sensorID,
+                                enable_mah_outlier_rejection, mah_threshold),
         n_zp_(n_zp),
         fixed_covariance_(fixed_covariance),
         fixedstates_(fixedstates) {

--- a/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
@@ -29,6 +29,10 @@ PressureSensorHandler::PressureSensorHandler(
       n_zp_(1e-6) {
   ros::NodeHandle pnh("~/pressure_sensor");
   ros::NodeHandle nh("msf_updates");
+
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+
   subPressure_ =
       nh.subscribe<geometry_msgs::PointStamped>
       ("pressure_height", 20, &PressureSensorHandler::MeasurementCallback, this);
@@ -58,8 +62,9 @@ void PressureSensorHandler::MeasurementCallback(
   }
 
   shared_ptr<pressure_measurement::PressureMeasurement> meas(
-      new pressure_measurement::PressureMeasurement(n_zp_, true,
-                                                    this->sensorID));
+      new pressure_measurement::PressureMeasurement(
+          n_zp_, true, this->sensorID, enable_mah_outlier_rejection_,
+          mah_threshold_));
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec());
 
   z_p_ = meas->z_p_;  // Store this for the init procedure.

--- a/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
@@ -31,7 +31,7 @@ PressureSensorHandler::PressureSensorHandler(
   ros::NodeHandle nh("msf_updates");
 
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
-  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+  pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
   subPressure_ =
       nh.subscribe<geometry_msgs::PointStamped>

--- a/msf_updates/include/msf_updates/pressure_sensor_handler/pressure_measurement.h
+++ b/msf_updates/include/msf_updates/pressure_sensor_handler/pressure_measurement.h
@@ -58,13 +58,13 @@ struct PressureMeasurement : public PressureMeasurementBase {
 
   typedef msf_updates::EKFState EKFState_T;
   typedef EKFState_T::StateDefinition_T StateDefinition_T;
-  virtual ~PressureMeasurement() { }
-  PressureMeasurement(double n_zp, bool isabsoluteMeasurement, int sensorID)
-      : PressureMeasurementBase(isabsoluteMeasurement, sensorID),
-        n_zp_(n_zp) { }
-  virtual std::string Type() {
-    return "pressure";
-  }
+  virtual ~PressureMeasurement() {}
+  PressureMeasurement(double n_zp, bool isabsoluteMeasurement, int sensorID,
+                      bool enable_mah_outlier_rejection, double mah_threshold)
+      : PressureMeasurementBase(isabsoluteMeasurement, sensorID,
+                                enable_mah_outlier_rejection, mah_threshold),
+        n_zp_(n_zp) {}
+  virtual std::string Type() { return "pressure"; }
   /**
    * The method called by the msf_core to apply the measurement represented by
    * this object.

--- a/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
@@ -36,7 +36,7 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
-  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+  pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
   ROS_INFO_COND(use_fixed_covariance_,
                 "Angle sensor is using fixed covariance");
@@ -132,7 +132,7 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
-  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
+  pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
   ROS_INFO_COND(use_fixed_covariance_,
                 "Distance sensor is using fixed covariance");

--- a/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
@@ -35,6 +35,8 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
   ros::NodeHandle pnh("~/spherical_position_sensor");
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
   ROS_INFO_COND(use_fixed_covariance_,
                 "Angle sensor is using fixed covariance");
@@ -105,10 +107,10 @@ void AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(
     }
   }
 
-  typename boost::shared_ptr<MEASUREMENT_TYPE> meas(
-      new MEASUREMENT_TYPE(n_za_, use_fixed_covariance_,
-                           provides_absolute_measurements_, this->sensorID,
-                           fixedstates));
+  typename boost::shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
+      n_za_, use_fixed_covariance_, provides_absolute_measurements_,
+      this->sensorID, fixedstates, enable_mah_outlier_rejection_,
+      mah_threshold_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 
@@ -129,6 +131,8 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
   ros::NodeHandle pnh("~/spherical_position_sensor");
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("mah_threshold", mah_threshold_, default_mah_threshold_);
 
   ROS_INFO_COND(use_fixed_covariance_,
                 "Distance sensor is using fixed covariance");
@@ -197,10 +201,10 @@ void DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(
     }
   }
 
-  typename boost::shared_ptr<MEASUREMENT_TYPE> meas(
-      new MEASUREMENT_TYPE(n_zd_, use_fixed_covariance_,
-                           provides_absolute_measurements_, this->sensorID,
-                           fixedstates));
+  typename boost::shared_ptr<MEASUREMENT_TYPE> meas(new MEASUREMENT_TYPE(
+      n_zd_, use_fixed_covariance_, provides_absolute_measurements_,
+      this->sensorID, fixedstates, enable_mah_outlier_rejection_,
+      mah_threshold_));
 
   meas->MakeFromSensorReading(msg, msg->header.stamp.toSec() - delay_);
 

--- a/msf_updates/include/msf_updates/spherical_position_sensor/spherical_measurement.h
+++ b/msf_updates/include/msf_updates/spherical_position_sensor/spherical_measurement.h
@@ -82,12 +82,13 @@ struct AngleMeasurement : public AngleMeasurementBase {
   virtual ~AngleMeasurement() {
   }
   AngleMeasurement(double n_za, bool fixed_covariance,
-                   bool isabsoluteMeasurement, int sensorID, int fixedstates)
-      : AngleMeasurementBase(isabsoluteMeasurement, sensorID),
+                   bool isabsoluteMeasurement, int sensorID, int fixedstates,
+                   bool enable_mah_outlier_rejection, double mah_threshold)
+      : AngleMeasurementBase(isabsoluteMeasurement, sensorID,
+                             enable_mah_outlier_rejection, mah_threshold),
         n_za_(n_za),
         fixed_covariance_(fixed_covariance),
-        fixedstates_(fixedstates) {
-  }
+        fixedstates_(fixedstates) {}
   virtual std::string Type() {
     return "angle";
   }
@@ -367,12 +368,13 @@ struct DistanceMeasurement : public DistanceMeasurementBase {
   virtual ~DistanceMeasurement() {
   }
   DistanceMeasurement(double n_zd, bool fixed_covariance,
-                      bool isabsoluteMeasurement, int sensorID, int fixedstates)
-      : DistanceMeasurementBase(isabsoluteMeasurement, sensorID),
+                      bool isabsoluteMeasurement, int sensorID, int fixedstates,
+                      bool enable_mah_outlier_rejection, double mah_threshold)
+      : DistanceMeasurementBase(isabsoluteMeasurement, sensorID,
+                                enable_mah_outlier_rejection, mah_threshold),
         n_zd_(n_zd),
         fixed_covariance_(fixed_covariance),
-        fixedstates_(fixedstates) {
-  }
+        fixedstates_(fixedstates) {}
   virtual std::string Type() {
     return "distance";
   }


### PR DESCRIPTION
Sorry for the masses of commits found it easiest to commit to github and pull to auk while testing.

Places a simple mahalanobis distance check into msf. If a reading fails a check the filter ignores the measurment. It is disabled by default