### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ ethzasl_msf
 Time delay compensated single and multi sensor fusion framework based on an EKF.
 Please see the wiki for more information: https://github.com/ethz-asl/ethzasl_msf/wiki
 
-##Documentation
+## Documentation
 The API is documented here: http://ethz-asl.github.io/ethzasl_msf
 
-##Contributing
+## Contributing
 You are welcome contributing to the package by opening a pull-request:
 Please make yourself familiar with the Google c++ style guide: 
 http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
 
-##License
+## License
 The source code is released under the Apache 2.0 license


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
