### PR TITLE
Maplab Msg Publish

### DIFF
--- a/msf_core/include/msf_core/implementation/msf_state_inl.h
+++ b/msf_core/include/msf_core/implementation/msf_state_inl.h
@@ -147,6 +147,43 @@ void GenericState_T<stateVector_T, StateDefinition_T>::ToOdometryMsg(
   GetTwistCovarianceInImuFrame(odometry.twist.covariance);
 }
 
+/// Assembles an Maplab Odometry message from the state.
+/** it does not set the header */
+template<typename stateVector_T, typename StateDefinition_T>
+void GenericState_T<stateVector_T, StateDefinition_T>::ToMaplabOdometryMsg(
+    maplab_msgs::OdometryWithImuBiases& odometry) {
+  eigen_conversions::Vector3dToPoint(Get<StateDefinition_T::p>(),
+                                     odometry.pose.pose.position);
+  eigen_conversions::QuaternionToMsg(Get<StateDefinition_T::q>(),
+                                     odometry.pose.pose.orientation);
+  GetPoseCovariance(odometry.pose.covariance);
+
+  const msf_core::Quaternion& q_W_I = Get<StateDefinition_T::q>();
+
+  // Express velocity in body frame as demanded 
+  // by the ROS odometry message specification.
+  const msf_core::Vector3& v_W =  Get<StateDefinition_T::v>();
+  const msf_core::Vector3 v_I = q_W_I.inverse().toRotationMatrix() * v_W;
+  eigen_conversions::Vector3dToPoint(v_I,
+                                     odometry.twist.twist.linear);
+
+  // Subtract bias from gyro measurement.
+  eigen_conversions::Vector3dToPoint(w_m - Get<StateDefinition_T::b_w>(),
+                                     odometry.twist.twist.angular);
+
+  GetTwistCovarianceInImuFrame(odometry.twist.covariance);
+
+  // State of the odometry
+  odometry.odometry_state = 0u;
+
+  // Bias
+  eigen_conversions::Vector3dToPoint(Get<StateDefinition_T::b_w>(),
+                                     odometry.gyro_bias);
+  eigen_conversions::Vector3dToPoint(Get<StateDefinition_T::b_a>(),
+                                     odometry.accel_bias);
+
+}
+
 /// Assembles an ExtState message from the state
 /** it does not set the header */
 template<typename stateVector_T, typename StateDefinition_T>

--- a/msf_core/include/msf_core/msf_sensormanagerROS.h
+++ b/msf_core/include/msf_core/msf_sensormanagerROS.h
@@ -204,7 +204,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
   virtual void PublishStateAfterPropagation(
       const shared_ptr<EKFState_T>& state) const {
 
-    if (pubPoseCrtl_.getNumSubscribers() || pubPose_.getNumSubscribers() || pubOdometry_.getNumSubscribers()) {
+    if (pubPoseCrtl_.getNumSubscribers() || pubPose_.getNumSubscribers() || pubOdometry_.getNumSubscribers() || pubMaplabOdometry_.getNumSubscribers()) {
       static int msg_seq = 0;
 
       geometry_msgs::PoseWithCovarianceStamped msgPose;
@@ -223,15 +223,13 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
       state->ToOdometryMsg(msgOdometry);
       pubOdometry_.publish(msgOdometry);
 
-      std::cout << "BEFORE PUBLISH" << std::endl; 
       maplab_msgs::OdometryWithImuBiases msgMaplabOdometry;
-      msgOdometry.header.stamp = ros::Time(state->time);
-      msgOdometry.header.seq = msg_seq++;
-      msgOdometry.header.frame_id = msf_output_frame_;
-      msgOdometry.child_frame_id = "imu";
+      msgMaplabOdometry.header.stamp = ros::Time(state->time);
+      msgMaplabOdometry.header.seq = msg_seq++;
+      msgMaplabOdometry.header.frame_id = msf_output_frame_;
+      msgMaplabOdometry.child_frame_id = "imu";
       state->ToMaplabOdometryMsg(msgMaplabOdometry);
       pubMaplabOdometry_.publish(msgMaplabOdometry);
-      std::cout << "AFTER PUBLISH" << std::endl; 
 
       sensor_fusion_comm::ExtState msgPoseCtrl;
       msgPoseCtrl.header = msgPose.header;

--- a/msf_core/include/msf_core/msf_state.h
+++ b/msf_core/include/msf_core/msf_state.h
@@ -30,6 +30,7 @@
 #include <sensor_fusion_comm/DoubleArrayStamped.h>
 #include <sensor_fusion_comm/DoubleMatrixStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <maplab_msgs/OdometryWithImuBiases.h>
 
 namespace msf_core {
 
@@ -226,6 +227,12 @@ struct GenericState_T {
    * \note It does not set the header.
    */
   void ToOdometryMsg(nav_msgs::Odometry& odometry);
+
+  /**
+   * \brief Assembles a Maplab Odometry message from the state.
+   * \note It does not set the header.
+   */
+  void ToMaplabOdometryMsg(maplab_msgs::OdometryWithImuBiases& odometry);
 
   /**
    * \brief Assemble an ExtState message from the state.

--- a/msf_core/package.xml
+++ b/msf_core/package.xml
@@ -24,6 +24,8 @@
   <build_depend>tf</build_depend>
   <build_depend>glog_catkin</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>maplab_msgs</build_depend>
+
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
@@ -31,4 +33,6 @@
   <run_depend>msf_timing</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>glog_catkin</run_depend>
+  <run_depend>maplab_msgs</run_depend>
+
 </package>


### PR DESCRIPTION
# Publish the fused state as a maplab msg with biases

## General

This adds the possibility to add a publish for maplab odometry msg which consists of pose, twist and imu biases. 

Map building
![image](https://user-images.githubusercontent.com/1336474/62908680-80bbe200-bd79-11e9-8bcf-d564b27068fd.png)

After optimization: 
![image](https://user-images.githubusercontent.com/1336474/62908748-e6a86980-bd79-11e9-8010-aff36793beff.png)


## Changelog 
* The msf core state can now populate maplab odometry msgs
* Publish of the odometry msg