### PR TITLE
Allow initializing with full quaternion.

### DIFF
--- a/msf_updates/cfg/SinglePositionSensor.cfg
+++ b/msf_updates/cfg/SinglePositionSensor.cfg
@@ -35,7 +35,10 @@ MISC            = gen.const("MISC",                     int_t, 0x00000002, "misc
 gen.add("core_init_filter",       bool_t,   INIT_FILTER["value"],                    "call filter init using defined scale",                    False)
 
 gen.add("position_noise_meas",      double_t, 	MISC["value"],                  "noise for measurement sensor (std. dev)",         0.01,          0,       10)
-gen.add("position_yaw_init",		double_t, 	MISC["value"],                  "initial value of yaw",         0,          -180,       180)
+gen.add("position_q_IB_x",         double_t,   MISC["value"],                  "initial value q_IB_x", 0.0, -1.0, 1.0)
+gen.add("position_q_IB_y",         double_t,   MISC["value"],                  "initial value q_IB_y", 0.0, -1.0, 1.0)
+gen.add("position_q_IB_z",         double_t,   MISC["value"],                  "initial value q_IB_z", 0.0, -1.0, 1.0)
+gen.add("position_q_IB_w",         double_t,   MISC["value"],                  "initial value q_IB_w", 1.0, -1.0, 1.0)
 gen.add("position_delay",        	double_t, 	MISC["value"],                  "fix delay in seconds",               0.02,       -2.0,     2.0)
 gen.add("position_noise_p_ip",      double_t, MISC["value"],                    "propagation: noise p_ip (std. dev)",           0.0,        0,          10.0)
 gen.add("position_fixed_p_ip", 		bool_t, 	MISC["value"], 					"fix calibration state position", False)

--- a/msf_updates/src/position_msf/position_sensormanager.h
+++ b/msf_updates/src/position_msf/position_sensormanager.h
@@ -109,13 +109,13 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
     v << 0, 0, 0;			/// Robot velocity (IMU centered).
     w_m << 0, 0, 0;		/// Initial angular velocity.
 
-    // Set the initial yaw alignment of body to world (the frame in which the
+    // Set the initial alignment of body to world (the frame in which the
     // position sensor measures).
-    double yawinit = config_.position_yaw_init / 180 * M_PI;
-    Eigen::Quaterniond yawq(cos(yawinit / 2), 0, 0, sin(yawinit / 2));
-    yawq.normalize();
-
-    q = yawq;
+    q.x() = config_.position_q_IB_x;
+    q.y() = config_.position_q_IB_y;
+    q.z() = config_.position_q_IB_z;
+    q.w() = config_.position_q_IB_w;
+    q.normalize();
 
     P.setZero();  // Error state covariance; if zero, a default initialization
                   // in msf_core is used


### PR DESCRIPTION
This PR exposes initialization using the full orientation. This becomes useful when starting MSF with an IMU that is not perfectly aligned with the inertial frame. May solve https://github.com/ethz-asl/ethzasl_msf/issues/169 and others.

Remarks:
- This PR does not solve the issue that MSF is initialized from parameter server instead of the first message arriving which would be more convenient in my opinion. In our case we wrote an extra node that reads the first IMU orientation and GPS position from ROS messages and then writes it to dynamic reconfigure. I can share this node if desired.
- This PR removes initialization from yaw only. If there is a neat or preferred way to preserve backwards compatibility we can implement that. Let me know.