### PR TITLE
Feature/param for state frame

### DIFF
--- a/msf_core/include/msf_core/msf_sensormanagerROS.h
+++ b/msf_core/include/msf_core/msf_sensormanagerROS.h
@@ -358,7 +358,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
       tf_broadcaster_.sendTransform(
           tf::StampedTransform(
               transform, ros::Time::now() /*ros::Time(latestState->time_)*/,
-              msf_output_frame_, msf_state_frame));
+              msf_output_frame_, msf_state_frame_));
     }
 
     if (pubCovCore_.getNumSubscribers()) {

--- a/msf_core/include/msf_core/msf_sensormanagerROS.h
+++ b/msf_core/include/msf_core/msf_sensormanagerROS.h
@@ -358,7 +358,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
       tf_broadcaster_.sendTransform(
           tf::StampedTransform(
               transform, ros::Time::now() /*ros::Time(latestState->time_)*/,
-              msf_output_frame_, msf_output_frame_));
+              msf_output_frame_, msf_state_frame));
     }
 
     if (pubCovCore_.getNumSubscribers()) {

--- a/msf_core/include/msf_core/msf_sensormanagerROS.h
+++ b/msf_core/include/msf_core/msf_sensormanagerROS.h
@@ -73,6 +73,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
   ros::Publisher pubCovCoreAux_; ///< Publishes the covariance matrix for the cross-correlations between core and auxiliary states.
 
   std::string msf_output_frame_;
+  std::string msf_state_frame_;
 
   mutable tf::TransformBroadcaster tf_broadcaster_;
 
@@ -89,6 +90,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
 
     pnh.param("data_playback", this->data_playback_, false);
     pnh.param("msf_output_frame", msf_output_frame_, std::string("world"));
+    pnh.param("msf_state_frame", msf_state_frame_, std::string("state"));
 
     ros::NodeHandle nh("msf_core");
 
@@ -356,7 +358,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
       tf_broadcaster_.sendTransform(
           tf::StampedTransform(
               transform, ros::Time::now() /*ros::Time(latestState->time_)*/,
-              msf_output_frame_, "state"));
+              msf_output_frame_, msf_output_frame_));
     }
 
     if (pubCovCore_.getNumSubscribers()) {


### PR DESCRIPTION
PR adds possibility to specify TF frame of msf's output. Default is set to used hard-coded value "state".
This is needed because ANYmal runs 2 MSFs: one with alphasense imu and one with body imu and therefore the 2 msf nodes were publishing 2 frames with the same name (state) 