### PR TITLE
Fix increasing buffer issue

### DIFF
--- a/msf_core/include/msf_core/msf_sortedContainer.h
+++ b/msf_core/include/msf_core/msf_sortedContainer.h
@@ -302,9 +302,10 @@ class SortedContainer {
    */
   inline void ClearOlderThan(double age) {
     double newest = GetLast()->time;
-    iterator_T it = GetIteratorClosest(newest - age);
-    if (newest - it->second->time < age)
+    double oldest = GetFirst()->time;
+    if (newest - oldest < age)
       return;  //there is no state older than time
+    iterator_T it = GetIteratorClosest(newest - age);
     if (it->second->time > stateList.begin()->second->time)
       stateList.erase(stateList.begin(), it);
   }


### PR DESCRIPTION
I experienced RAM filling up since the removal of old buffer values was never triggered, since the condition `if (newest - it->second->time < age)` was never true. After investigation I found the following: The tested sensor publishes data such that there is always a newer measurement (e.g 59.97 seconds in the past) closer to 60 seconds than the previous one (e.g 60.07 seconds in the past). Thus, `GetIteratorClosest(newest - age)` always returns the iterator to the object that is younger than 60 seconds, which leads to the condition `newest - it->second->time < age` being false and eventually no elements are ever removed from the container.
The fix in this PR solves that issue by not comparing the time between the newest and the closest value to 60 seconds but by comparing the the time between the newest and the oldest measurement in the buffer.