### PR TITLE
Feature/tcpnodelay

### DIFF
--- a/msf_core/include/msf_core/msf_IMUHandler_ROS.h
+++ b/msf_core/include/msf_core/msf_IMUHandler_ROS.h
@@ -35,10 +35,13 @@ class IMUHandler_ROS : public IMUHandler<EKFState_T> {
 
     ros::NodeHandle nh(topic_namespace);
 
+    MSF_INFO_STREAM_COND(static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay(), "IMU sensor uses TCP no delay.");
+    MSF_INFO_STREAM_COND(!static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay(), "IMU sensor does not use TCP no delay.");
+
     subImu_ = nh.subscribe("imu_state_input", 100, &IMUHandler_ROS::IMUCallback,
-                           this);
+                           this, static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay() ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
     subState_ = nh.subscribe("hl_state_input", 10,
-                             &IMUHandler_ROS::StateCallback, this);
+                             &IMUHandler_ROS::StateCallback, this, static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay() ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
   }
 
   virtual ~IMUHandler_ROS() { }

--- a/msf_core/include/msf_core/msf_IMUHandler_ROS.h
+++ b/msf_core/include/msf_core/msf_IMUHandler_ROS.h
@@ -35,13 +35,27 @@ class IMUHandler_ROS : public IMUHandler<EKFState_T> {
 
     ros::NodeHandle nh(topic_namespace);
 
-    MSF_INFO_STREAM_COND(static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay(), "IMU sensor uses TCP no delay.");
-    MSF_INFO_STREAM_COND(!static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay(), "IMU sensor does not use TCP no delay.");
+    MSF_INFO_STREAM_COND(
+        static_cast<MSF_SensorManagerROS<EKFState_T> &>(this->manager_)
+            .GetParamEnableTcpNoDelay(),
+        "IMU sensor uses TCP no delay.");
+    MSF_INFO_STREAM_COND(
+        !static_cast<MSF_SensorManagerROS<EKFState_T> &>(this->manager_)
+             .GetParamEnableTcpNoDelay(),
+        "IMU sensor does not use TCP no delay.");
 
-    subImu_ = nh.subscribe("imu_state_input", 100, &IMUHandler_ROS::IMUCallback,
-                           this, static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay() ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
-    subState_ = nh.subscribe("hl_state_input", 10,
-                             &IMUHandler_ROS::StateCallback, this, static_cast<MSF_SensorManagerROS<EKFState_T>&>(this->manager_).GetParamEnableTcpNoDelay() ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+    subImu_ = nh.subscribe(
+        "imu_state_input", 100, &IMUHandler_ROS::IMUCallback, this,
+        static_cast<MSF_SensorManagerROS<EKFState_T> &>(this->manager_)
+                .GetParamEnableTcpNoDelay()
+            ? ros::TransportHints().tcpNoDelay()
+            : ros::TransportHints());
+    subState_ = nh.subscribe(
+        "hl_state_input", 10, &IMUHandler_ROS::StateCallback, this,
+        static_cast<MSF_SensorManagerROS<EKFState_T> &>(this->manager_)
+                .GetParamEnableTcpNoDelay()
+            ? ros::TransportHints().tcpNoDelay()
+            : ros::TransportHints());
   }
 
   virtual ~IMUHandler_ROS() { }

--- a/msf_core/include/msf_core/msf_sensormanagerROS.h
+++ b/msf_core/include/msf_core/msf_sensormanagerROS.h
@@ -73,6 +73,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
   std::string msf_output_frame_;
   std::string odom_child_frame_;
   std::string tf_target_frame_;
+  bool enable_tcp_no_delay_; ///< Subscribe to sensor with minimum TCP delay (requires more CPU).
 
   mutable tf::TransformBroadcaster tf_broadcaster_;
 
@@ -91,6 +92,7 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
     pnh.param("msf_output_frame", msf_output_frame_, std::string("world"));
     pnh.param("odometry_child_frame", odom_child_frame_, std::string("imu"));
     pnh.param("tf_target_frame", tf_target_frame_, std::string("state"));
+    pnh.param("enable_tcp_no_delay", enable_tcp_no_delay_, false);
 
     ros::NodeHandle nh("msf_core");
 
@@ -174,6 +176,9 @@ struct MSF_SensorManagerROS : public msf_core::MSF_SensorManager<EKFState_T> {
   }
   virtual double GetParamFuzzyTrackingThreshold() const {
     return 0.1;
+  }
+  virtual bool GetParamEnableTcpNoDelay() const {
+    return enable_tcp_no_delay_;
   }
   virtual void PublishStateInitial(const shared_ptr<EKFState_T>& state) const {
     /**

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -43,6 +43,8 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
             true);
   pnh.param("pose_measurement_world_sensor", measurement_world_sensor_, true);
   pnh.param("pose_use_fixed_covariance", use_fixed_covariance_, false);
+  bool enable_tcp_no_delay;
+  pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
   pnh.param("pose_measurement_minimum_dt", pose_measurement_minimum_dt_, 0.05);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
@@ -60,6 +62,9 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
                        "Pose sensor is using covariance "
                        "from sensor");
 
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Pose sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Pose sensor does not use TCP no delay.");
+
   MSF_INFO_STREAM_COND(provides_absolute_measurements_,
                        "Pose sensor is handling "
                        "measurements as absolute values");
@@ -69,11 +74,11 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
   ros::NodeHandle nh("msf_updates/" + topic_namespace);
   subPoseWithCovarianceStamped_ =
       nh.subscribe < geometry_msgs::PoseWithCovarianceStamped
-          > ("pose_with_covariance_input", 20, &PoseSensorHandler::MeasurementCallback, this);
+          > ("pose_with_covariance_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
   subTransformStamped_ = nh.subscribe < geometry_msgs::TransformStamped
-      > ("transform_input", 20, &PoseSensorHandler::MeasurementCallback, this);
+      > ("transform_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
   subPoseStamped_ = nh.subscribe < geometry_msgs::PoseStamped
-      > ("pose_input", 20, &PoseSensorHandler::MeasurementCallback, this);
+      > ("pose_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
 
   z_p_.setZero();
   z_q_.setIdentity();

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -63,7 +63,8 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
                        "from sensor");
 
   MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Pose sensor uses TCP no delay.");
-  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Pose sensor does not use TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay,
+                       "Pose sensor does not use TCP no delay.");
 
   MSF_INFO_STREAM_COND(provides_absolute_measurements_,
                        "Pose sensor is handling "
@@ -73,12 +74,19 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
 
   ros::NodeHandle nh("msf_updates/" + topic_namespace);
   subPoseWithCovarianceStamped_ =
-      nh.subscribe < geometry_msgs::PoseWithCovarianceStamped
-          > ("pose_with_covariance_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
-  subTransformStamped_ = nh.subscribe < geometry_msgs::TransformStamped
-      > ("transform_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
-  subPoseStamped_ = nh.subscribe < geometry_msgs::PoseStamped
-      > ("pose_input", 20, &PoseSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+      nh.subscribe<geometry_msgs::PoseWithCovarianceStamped>(
+          "pose_with_covariance_input", 20,
+          &PoseSensorHandler::MeasurementCallback, this,
+          enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                              : ros::TransportHints());
+  subTransformStamped_ = nh.subscribe<geometry_msgs::TransformStamped>(
+      "transform_input", 20, &PoseSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
+  subPoseStamped_ = nh.subscribe<geometry_msgs::PoseStamped>(
+      "pose_input", 20, &PoseSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
 
   z_p_.setZero();
   z_q_.setIdentity();

--- a/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
@@ -33,6 +33,8 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
       delay_(0) {
   ros::NodeHandle pnh("~/position_sensor");
   pnh.param("position_use_fixed_covariance", use_fixed_covariance_, false);
+  bool enable_tcp_no_delay;
+  pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
   pnh.param("position_absolute_measurements", provides_absolute_measurements_,
             false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
@@ -43,6 +45,9 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
   MSF_INFO_STREAM_COND(!use_fixed_covariance_, "Position sensor is using "
                        "covariance from sensor");
 
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Position sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Position sensor does not use TCP no delay.");
+
   MSF_INFO_STREAM_COND(provides_absolute_measurements_, "Position sensor is "
                        "handling measurements as absolute values");
   MSF_INFO_STREAM_COND(!provides_absolute_measurements_, "Position sensor is "
@@ -52,13 +57,13 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
 
   subPointStamped_ =
       nh.subscribe<geometry_msgs::PointStamped>
-  ("position_input", 20, &PositionSensorHandler::MeasurementCallback, this);
+  ("position_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
   subTransformStamped_ =
       nh.subscribe<geometry_msgs::TransformStamped>
-  ("transform_input", 20, &PositionSensorHandler::MeasurementCallback, this);
+  ("transform_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
   subNavSatFix_ =
       nh.subscribe<sensor_msgs::NavSatFix>
-  ("navsatfix_input", 20, &PositionSensorHandler::MeasurementCallback, this);
+  ("navsatfix_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
 
   z_p_.setZero();
 

--- a/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
@@ -45,8 +45,10 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
   MSF_INFO_STREAM_COND(!use_fixed_covariance_, "Position sensor is using "
                        "covariance from sensor");
 
-  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Position sensor uses TCP no delay.");
-  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Position sensor does not use TCP no delay.");
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay,
+                       "Position sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay,
+                       "Position sensor does not use TCP no delay.");
 
   MSF_INFO_STREAM_COND(provides_absolute_measurements_, "Position sensor is "
                        "handling measurements as absolute values");
@@ -55,15 +57,18 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
 
   ros::NodeHandle nh("msf_updates");
 
-  subPointStamped_ =
-      nh.subscribe<geometry_msgs::PointStamped>
-  ("position_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
-  subTransformStamped_ =
-      nh.subscribe<geometry_msgs::TransformStamped>
-  ("transform_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
-  subNavSatFix_ =
-      nh.subscribe<sensor_msgs::NavSatFix>
-  ("navsatfix_input", 20, &PositionSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+  subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>(
+      "position_input", 20, &PositionSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
+  subTransformStamped_ = nh.subscribe<geometry_msgs::TransformStamped>(
+      "transform_input", 20, &PositionSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
+  subNavSatFix_ = nh.subscribe<sensor_msgs::NavSatFix>(
+      "navsatfix_input", 20, &PositionSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
 
   z_p_.setZero();
 

--- a/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
@@ -32,15 +32,19 @@ PressureSensorHandler::PressureSensorHandler(
 
   bool enable_tcp_no_delay;
   pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
-  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
+  pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_,
+            false);
   pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
-  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Pressure sensor uses TCP no delay.");
-  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Pressure sensor does not use TCP no delay.");
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay,
+                       "Pressure sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay,
+                       "Pressure sensor does not use TCP no delay.");
 
-  subPressure_ =
-      nh.subscribe<geometry_msgs::PointStamped>
-      ("pressure_height", 20, &PressureSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+  subPressure_ = nh.subscribe<geometry_msgs::PointStamped>(
+      "pressure_height", 20, &PressureSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
 
   memset(heightbuff, 0, sizeof(double) * heightbuffsize);
 

--- a/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pressure_sensor_handler/implementation/pressure_sensorhandler.hpp
@@ -30,12 +30,17 @@ PressureSensorHandler::PressureSensorHandler(
   ros::NodeHandle pnh("~/pressure_sensor");
   ros::NodeHandle nh("msf_updates");
 
+  bool enable_tcp_no_delay;
+  pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
 
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Pressure sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Pressure sensor does not use TCP no delay.");
+
   subPressure_ =
       nh.subscribe<geometry_msgs::PointStamped>
-      ("pressure_height", 20, &PressureSensorHandler::MeasurementCallback, this);
+      ("pressure_height", 20, &PressureSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
 
   memset(heightbuff, 0, sizeof(double) * heightbuffsize);
 

--- a/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
@@ -34,6 +34,8 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
       delay_(0) {
   ros::NodeHandle pnh("~/spherical_position_sensor");
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
+  bool enable_tcp_no_delay;
+  pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
@@ -43,6 +45,9 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
   ROS_INFO_COND(!use_fixed_covariance_,
                 "Angle sensor is using covariance from sensor");
 
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Angle sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Angle sensor does not use TCP no delay.");
+
   ROS_INFO_COND(provides_absolute_measurements_,
                 "Angle sensor is handling measurements as absolute values");
   ROS_INFO_COND(!provides_absolute_measurements_,
@@ -51,7 +56,7 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
   ros::NodeHandle nh("msf_updates");
 
   subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>
-      ("angle_input", 20, &AngleSensorHandler::MeasurementCallback, this);
+      ("angle_input", 20, &AngleSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
 
   z_a_.setZero();
 
@@ -130,6 +135,8 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
       delay_(0) {
   ros::NodeHandle pnh("~/spherical_position_sensor");
   pnh.param("use_fixed_covariance", use_fixed_covariance_, true);
+  bool enable_tcp_no_delay;
+  pnh.param("enable_tcp_no_delay", enable_tcp_no_delay, false);
   pnh.param("absolute_measurements", provides_absolute_measurements_, false);
   pnh.param("enable_mah_outlier_rejection", enable_mah_outlier_rejection_, false);
   pnh.param("mah_threshold", mah_threshold_, msf_core::kDefaultMahThreshold_);
@@ -138,6 +145,9 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
                 "Distance sensor is using fixed covariance");
   ROS_INFO_COND(!use_fixed_covariance_,
                 "Distance sensor is using covariance from sensor");
+
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Distance sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Distance sensor does not use TCP no delay.");
 
   ROS_INFO_COND(provides_absolute_measurements_,
                 "Distance sensor is handling measurements as absolute values");
@@ -148,7 +158,7 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
 
   subPointStamped_ =
       nh.subscribe<geometry_msgs::PointStamped>
-      ("distance_input", 20, &DistanceSensorHandler::MeasurementCallback, this);
+      ("distance_input", 20, &DistanceSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
 
   z_d_.setZero();
 

--- a/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/spherical_position_sensor/implementation/spherical_sensorhandler.hpp
@@ -46,7 +46,8 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
                 "Angle sensor is using covariance from sensor");
 
   MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Angle sensor uses TCP no delay.");
-  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Angle sensor does not use TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay,
+                       "Angle sensor does not use TCP no delay.");
 
   ROS_INFO_COND(provides_absolute_measurements_,
                 "Angle sensor is handling measurements as absolute values");
@@ -55,8 +56,10 @@ AngleSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::AngleSensorHandler(
 
   ros::NodeHandle nh("msf_updates");
 
-  subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>
-      ("angle_input", 20, &AngleSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+  subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>(
+      "angle_input", 20, &AngleSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
 
   z_a_.setZero();
 
@@ -146,8 +149,10 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
   ROS_INFO_COND(!use_fixed_covariance_,
                 "Distance sensor is using covariance from sensor");
 
-  MSF_INFO_STREAM_COND(enable_tcp_no_delay, "Distance sensor uses TCP no delay.");
-  MSF_INFO_STREAM_COND(!enable_tcp_no_delay, "Distance sensor does not use TCP no delay.");
+  MSF_INFO_STREAM_COND(enable_tcp_no_delay,
+                       "Distance sensor uses TCP no delay.");
+  MSF_INFO_STREAM_COND(!enable_tcp_no_delay,
+                       "Distance sensor does not use TCP no delay.");
 
   ROS_INFO_COND(provides_absolute_measurements_,
                 "Distance sensor is handling measurements as absolute values");
@@ -156,9 +161,10 @@ DistanceSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::DistanceSensorHandler(
 
   ros::NodeHandle nh("msf_updates");
 
-  subPointStamped_ =
-      nh.subscribe<geometry_msgs::PointStamped>
-      ("distance_input", 20, &DistanceSensorHandler::MeasurementCallback, this, enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay() : ros::TransportHints());
+  subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>(
+      "distance_input", 20, &DistanceSensorHandler::MeasurementCallback, this,
+      enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
+                          : ros::TransportHints());
 
   z_d_.setZero();
 

--- a/msf_updates/pose_pressure_sensor_fix.yaml
+++ b/msf_updates/pose_pressure_sensor_fix.yaml
@@ -2,6 +2,7 @@
 data_playback: true
 
 core/core_fixed_bias: false
+core/enable_tcp_no_delay: false
 
 #########IMU PARAMETERS#######
 ####### bluebird
@@ -54,3 +55,4 @@ pose_sensor/pose_fixed_q_wv: false
 pose_sensor/pose_absolute_measurements: true
 pose_sensor/pose_use_fixed_covariance: false
 pose_sensor/pose_measurement_world_sensor: false  # selects if sensor measures its position w.r.t. world (true, e.g. Vicon) or the position of the world coordinate system w.r.t. the sensor (false, e.g. ethzasl_ptam)
+pose_sensor/enable_tcp_no_delay: false

--- a/msf_updates/pose_sensor_fix.yaml
+++ b/msf_updates/pose_sensor_fix.yaml
@@ -30,6 +30,8 @@ core/core_fixed_bias: false
 core/core_noise_accbias: 8e-5     # [m/s^3/sqrt(Hz)]
 core/core_noise_gyrbias: 3e-6     # [rad/s^2/sqrt(Hz)]
 
+core/enable_tcp_no_delay: false
+
 ####### mpu6000
 #core/core_noise_acc: 0.003924    # [m/s^2/sqrt(Hz)] mpu6000 datasheet
 #core/core_noise_gyr: 0.00008726  # [rad/s/sqrt(Hz)] mpu6000 datasheet
@@ -42,6 +44,7 @@ core/core_noise_gyrbias: 3e-6     # [rad/s^2/sqrt(Hz)]
 #########Pose Sensor Parameters #######
 #######################################
 pose_sensor/pose_absolute_measurements: true
+pose_sensor/enable_tcp_no_delay: false
 pose_sensor/pose_measurement_world_sensor: false  # Selects if sensor measures its position 
                                                   # w.r.t. world (true, e.g. Vicon) or the position 
                                                   # of the world coordinate system w.r.t. the 

--- a/msf_updates/position_pose_sensor_fix.yaml
+++ b/msf_updates/position_pose_sensor_fix.yaml
@@ -2,6 +2,7 @@
 data_playback: true
 
 core/core_fixed_bias: false
+core/enable_tcp_no_delay: false
 
 #########IMU PARAMETERS#######
 ####### bluebird
@@ -50,10 +51,12 @@ position_pose_sensor/pose_fixed_p_ic: false
 position_pose_sensor/pose_fixed_q_ic: false
 position_pose_sensor/pose_fixed_p_wv: false
 position_pose_sensor/pose_fixed_q_wv: false
+position_pose_sensor/enable_tcp_no_delay: false
 
 pose_sensor/pose_absolute_measurements: false
 pose_sensor/pose_use_fixed_covariance: false
 pose_sensor/pose_measurement_world_sensor: false  # selects if sensor measures its position w.r.t. world (true, e.g. Vicon) or the position of the world coordinate system w.r.t. the sensor (false, e.g. ethzasl_ptam)
+pose_sensor/enable_tcp_no_delay: false
 
 position_pose_sensor/position_delay: 0.001
 position_pose_sensor/position_noise_meas: 0.1
@@ -70,5 +73,6 @@ position_pose_sensor/position_yaw_init: -128.0
 position_pose_sensor/position_fixed_p_ip: true
 position_sensor/position_use_fixed_covariance: false
 position_sensor/position_absolute_measurements: true
+position_sensor/enable_tcp_no_delay: false
 
 

--- a/msf_updates/position_sensor_fix.yaml
+++ b/msf_updates/position_sensor_fix.yaml
@@ -2,6 +2,7 @@ scale_init: 1
 data_playback: true
 
 core/core_fixed_bias: 0
+core/enable_tcp_no_delay: false
 
 #########IMU PARAMETERS#######
 ####### bluebird
@@ -27,3 +28,4 @@ position_sensor/init/p_ip/z: 0.05
 position_sensor/position_absolute_measurements: true
 position_sensor/position_use_fixed_covariance: true
 position_sensor/position_measurement_world_sensor: true  # selects if sensor measures its position w.r.t. world (true, e.g. Vicon) or the position of the world coordinate system w.r.t. the sensor (false, e.g. ethzasl_ptam)
+position_sensor/enable_tcp_no_delay: false

--- a/msf_updates/viconpos_sensor_fix.yaml
+++ b/msf_updates/viconpos_sensor_fix.yaml
@@ -3,6 +3,7 @@
 
 #########IMU PARAMETERS#######
 ######## Asctec Firefly IMU
+/pose_sensor/core/enable_tcp_no_delay: false
 /pose_sensor/core/core_noise_acc: 0.083
 /pose_sensor/core/core_noise_accbias: 0.0083
 /pose_sensor/core/core_noise_gyr: 0.0013
@@ -35,5 +36,6 @@
 /pose_sensor/pose_sensor/pose_absolute_measurements: true
 /pose_sensor/pose_sensor/pose_use_fixed_covariance: true
 /pose_sensor/pose_sensor/pose_measurement_world_sensor: true  # selects if sensor measures its position w.r.t. world (true, e.g. Vicon) or the position of the world coordinate system w.r.t. the sensor (false, e.g. ethzasl_ptam
+/pose_sensor/pose_sensor/enable_tcp_no_delay: false
 
 /pose_sensor/pose_sensor/pose_measurement_minimum_dt: 0.05  # Sets the minimum time in seconds between two pose measurements.


### PR DESCRIPTION
Gives you the option to subscribe to a sensor with TCP no delay transport hint. This is typically not necessary for very small messages types but still nice to have.