### PR TITLE
Feature/init biases from param

### DIFF
--- a/msf_core/include/msf_core/msf_sortedContainer.h
+++ b/msf_core/include/msf_core/msf_sortedContainer.h
@@ -302,9 +302,10 @@ class SortedContainer {
    */
   inline void ClearOlderThan(double age) {
     double newest = GetLast()->time;
-    iterator_T it = GetIteratorClosest(newest - age);
-    if (newest - it->second->time < age)
+    double oldest = GetFirst()->time;
+    if (newest - oldest < age)
       return;  //there is no state older than time
+    iterator_T it = GetIteratorClosest(newest - age);
     if (it->second->time > stateList.begin()->second->time)
       stateList.erase(stateList.begin(), it);
   }

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -92,8 +92,7 @@ PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PoseSensorHandler(
       enable_tcp_no_delay ? ros::TransportHints().tcpNoDelay()
                           : ros::TransportHints());
 
-
-    z_p_.setZero();
+  z_p_.setZero();
   z_q_.setIdentity();
 
   if (distortmeas) {

--- a/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/implementation/pose_sensorhandler.hpp
@@ -201,37 +201,36 @@ void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(
   ProcessPoseMeasurement(msg);
 }
 
-    template <typename MEASUREMENT_TYPE, typename MANAGER_TYPE>
-    void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(
-            const nav_msgs::OdometryConstPtr& msg) {
-        this->SequenceWatchDog(msg->header.seq, subOdometry_.getTopic());
-        MSF_INFO_STREAM_ONCE("*** pose sensor got first measurement from topic "
-                                     << this->topic_namespace_ << "/"
-                                     << subOdometry_.getTopic() << " ***");
+template <typename MEASUREMENT_TYPE, typename MANAGER_TYPE>
+void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(
+    const nav_msgs::OdometryConstPtr &msg) {
+  this->SequenceWatchDog(msg->header.seq, subOdometry_.getTopic());
+  MSF_INFO_STREAM_ONCE("*** pose sensor got first measurement from topic "
+                       << this->topic_namespace_ << "/"
+                       << subOdometry_.getTopic() << " ***");
 
-        double time_now = msg->header.stamp.toSec();
-        const double epsilon = 0.001;  // Small time correction to avoid rounding
-        // errors in the timestamps.
-        if (time_now - timestamp_previous_pose_ <=
-            pose_measurement_minimum_dt_ - epsilon) {
-            MSF_WARN_STREAM_THROTTLE(
-                    30,
-                    "Pose measurement throttling is on, dropping messages"
-                    "to be below " +
-                    std::to_string(1 / pose_measurement_minimum_dt_) + " Hz");
-            return;
-        }
+  double time_now = msg->header.stamp.toSec();
+  const double epsilon = 0.001; // Small time correction to avoid rounding
+  // errors in the timestamps.
+  if (time_now - timestamp_previous_pose_ <=
+      pose_measurement_minimum_dt_ - epsilon) {
+    MSF_WARN_STREAM_THROTTLE(
+        30, "Pose measurement throttling is on, dropping messages"
+            "to be below " +
+                std::to_string(1 / pose_measurement_minimum_dt_) + " Hz");
+    return;
+  }
 
-        timestamp_previous_pose_ = time_now;
+  timestamp_previous_pose_ = time_now;
 
-        geometry_msgs::PoseWithCovarianceStampedPtr pose(
-                new geometry_msgs::PoseWithCovarianceStamped());
+  geometry_msgs::PoseWithCovarianceStampedPtr pose(
+      new geometry_msgs::PoseWithCovarianceStamped());
 
-        pose->header = msg->header;
-        pose->pose = msg->pose;
+  pose->header = msg->header;
+  pose->pose = msg->pose;
 
-        ProcessPoseMeasurement(pose);
-    }
+  ProcessPoseMeasurement(pose);
+}
 
 template<typename MEASUREMENT_TYPE, typename MANAGER_TYPE>
 void PoseSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::MeasurementCallback(

--- a/msf_updates/include/msf_updates/pose_sensor_handler/pose_sensorhandler.h
+++ b/msf_updates/include/msf_updates/pose_sensor_handler/pose_sensorhandler.h
@@ -23,6 +23,7 @@
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <nav_msgs/Odometry.h>
 #include <msf_updates/PoseDistorter.h>
 
 namespace msf_pose_sensor {
@@ -32,8 +33,8 @@ class PoseSensorHandler : public msf_core::SensorHandler<
     typename msf_updates::EKFState> {
  private:
 
-  Eigen::Quaternion<double> z_q_;  ///< Attitude measurement camera seen from world.
-  Eigen::Matrix<double, 3, 1> z_p_;  ///< Position measurement camera seen from world.
+  Eigen::Quaternion<double> z_q_;  ///< Attitude measurement camera seen from world. (q_vc)
+  Eigen::Matrix<double, 3, 1> z_p_;  ///< Position measurement camera seen from world. (v_p_vc)
   double n_zp_, n_zq_;  ///< Position and attitude measurement noise.
   double delay_;        ///< Delay to be subtracted from the ros-timestamp of
   // the measurement provided by this sensor.
@@ -41,6 +42,7 @@ class PoseSensorHandler : public msf_core::SensorHandler<
   ros::Subscriber subPoseWithCovarianceStamped_;
   ros::Subscriber subTransformStamped_;
   ros::Subscriber subPoseStamped_;
+  ros::Subscriber subOdometry_;
 
   bool measurement_world_sensor_;  ///< Defines if the pose of the sensor is
                                    // measured in world coordinates (true, default)
@@ -62,8 +64,10 @@ class PoseSensorHandler : public msf_core::SensorHandler<
       const geometry_msgs::PoseWithCovarianceStampedConstPtr & msg);
   void MeasurementCallback(const geometry_msgs::PoseStampedConstPtr & msg);
   void MeasurementCallback(const geometry_msgs::TransformStampedConstPtr & msg);
+  void MeasurementCallback(const nav_msgs::OdometryConstPtr & msg);
 
- public:
+
+public:
   typedef MEASUREMENT_TYPE measurement_t;
   PoseSensorHandler(MANAGER_TYPE& meas, std::string topic_namespace,
                     std::string parameternamespace, bool distortmeas);

--- a/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
+++ b/msf_updates/include/msf_updates/position_sensor_handler/implementation/position_sensorhandler.hpp
@@ -55,7 +55,7 @@ PositionSensorHandler<MEASUREMENT_TYPE, MANAGER_TYPE>::PositionSensorHandler(
   MSF_INFO_STREAM_COND(!provides_absolute_measurements_, "Position sensor is "
                        "handling measurements as relative values");
 
-  ros::NodeHandle nh("msf_updates");
+  ros::NodeHandle nh("msf_updates/" + topic_namespace);
 
   subPointStamped_ = nh.subscribe<geometry_msgs::PointStamped>(
       "position_input", 20, &PositionSensorHandler::MeasurementCallback, this,

--- a/msf_updates/src/pose_msf/pose_sensormanager.h
+++ b/msf_updates/src/pose_msf/pose_sensormanager.h
@@ -158,8 +158,6 @@ class PoseSensorManager : public msf_core::MSF_SensorManagerROS<
 
     // init values
     g << 0, 0, 9.81;	        /// Gravity.
-    b_w << 0, 0, 0;		/// Bias gyroscopes.
-    b_a << 0, 0, 0;		/// Bias accelerometer.
 
     v << 0, 0, 0;			/// Robot velocity (IMU centered).
     w_m << 0, 0, 0;		/// Initial angular velocity.
@@ -184,6 +182,17 @@ class PoseSensorManager : public msf_core::MSF_SensorManagerROS<
           "No measurements received yet to initialize attitude - using [1 0 0 0]");
 
     ros::NodeHandle pnh("~");
+    pnh.param("core/init/b_w/x", b_w[0], 0.0);
+    pnh.param("core/init/b_w/y", b_w[1], 0.0);
+    pnh.param("core/init/b_w/z", b_w[2], 0.0);
+
+    pnh.param("core/init/b_a/x", b_a[0], 0.0);
+    pnh.param("core/init/b_a/y", b_a[1], 0.0);
+    pnh.param("core/init/b_a/z", b_a[2], 0.0);
+
+    MSF_INFO_STREAM("b_a: " << b_a.transpose());
+    MSF_INFO_STREAM("b_w: " << b_w.transpose());
+
     pnh.param("pose_sensor/init/p_ic/x", p_ic[0], 0.0);
     pnh.param("pose_sensor/init/p_ic/y", p_ic[1], 0.0);
     pnh.param("pose_sensor/init/p_ic/z", p_ic[2], 0.0);
@@ -205,7 +214,7 @@ class PoseSensorManager : public msf_core::MSF_SensorManagerROS<
     p = p_wv + q_wv.conjugate().toRotationMatrix() * p_vc / scale
         - q.toRotationMatrix() * p_ic;
 
-    a_m = q.inverse() * g;			/// Initial acceleration.
+    a_m = (q.inverse() * g) - b_a;			/// De-biased initial acceleration.
 
     // Prepare init "measurement"
     // True means that this message contains initial sensor readings.

--- a/msf_updates/src/position_msf/position_sensormanager.h
+++ b/msf_updates/src/position_msf/position_sensormanager.h
@@ -29,6 +29,9 @@
 #include <msf_updates/position_sensor_handler/position_measurement.h>
 #include <msf_updates/SinglePositionSensorConfig.h>
 
+#include "sensor_fusion_comm/InitScale.h"
+
+
 namespace msf_position_sensor {
 
 typedef msf_updates::SinglePositionSensorConfig Config_T;
@@ -62,6 +65,9 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
     ReconfigureServer::CallbackType f = boost::bind(
         &PositionSensorManager::Config, this, _1, _2);
     reconf_server_->setCallback(f);
+
+    init_scale_srv_ = pnh.advertiseService("initialize_msf_scale",
+                                           &PositionSensorManager::InitScale, this);
   }
   virtual ~PositionSensorManager() {
   }
@@ -76,6 +82,7 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
 
   Config_T config_;
   ReconfigureServerPtr reconf_server_;
+  ros::ServiceServer init_scale_srv_;
 
   /**
    * \brief Dynamic reconfigure callback.
@@ -91,6 +98,14 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
     }
   }
 
+  bool InitScale(sensor_fusion_comm::InitScale::Request &req,
+                 sensor_fusion_comm::InitScale::Response &res) {
+    ROS_INFO("Initialize filter with scale %f", req.scale);
+    Init(req.scale);
+    res.result = "Initialized scale";
+    return true;
+  }
+
   void Init(double scale) const {
     if (scale < 0.001) {
       MSF_WARN_STREAM("init scale is "<<scale<<" correcting to 1");
@@ -103,8 +118,6 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
 
     // Init values.
     g << 0, 0, 9.81;  /// Gravity.
-    b_w << 0, 0, 0;		/// Bias gyroscopes.
-    b_a << 0, 0, 0;		/// Bias accelerometer.
 
     v << 0, 0, 0;			/// Robot velocity (IMU centered).
     w_m << 0, 0, 0;		/// Initial angular velocity.
@@ -131,6 +144,17 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
           "No measurements received yet to initialize position - using [0 0 0]");
 
     ros::NodeHandle pnh("~");
+    pnh.param("core/init/b_w/x", b_w[0], 0.0);
+    pnh.param("core/init/b_w/y", b_w[1], 0.0);
+    pnh.param("core/init/b_w/z", b_w[2], 0.0);
+
+    pnh.param("core/init/b_a/x", b_a[0], 0.0);
+    pnh.param("core/init/b_a/y", b_a[1], 0.0);
+    pnh.param("core/init/b_a/z", b_a[2], 0.0);
+
+    MSF_INFO_STREAM("b_a: " << b_a.transpose());
+    MSF_INFO_STREAM("b_w: " << b_w.transpose());
+
     pnh.param("position_sensor/init/p_ip/x", p_ip[0], 0.0);
     pnh.param("position_sensor/init/p_ip/y", p_ip[1], 0.0);
     pnh.param("position_sensor/init/p_ip/z", p_ip[2], 0.0);
@@ -138,7 +162,7 @@ class PositionSensorManager : public msf_core::MSF_SensorManagerROS<
     // Calculate initial attitude and position based on sensor measurements.
     p = p_vc - q.toRotationMatrix() * p_ip;
 
-    a_m = q.inverse() * g;			    /// Initial acceleration.
+    a_m = (q.inverse() * g) - b_a;			    /// Initial acceleration.
 
     //prepare init "measurement"
     // True means that we will also set the initialsensor readings.

--- a/msf_updates/src/position_pose_msf/position_pose_sensormanager.h
+++ b/msf_updates/src/position_pose_msf/position_pose_sensormanager.h
@@ -29,6 +29,9 @@
 #include <msf_updates/position_sensor_handler/position_measurement.h>
 #include <msf_updates/PositionPoseSensorConfig.h>
 
+#include "sensor_fusion_comm/InitScale.h"
+
+
 namespace msf_updates {
 
 typedef msf_updates::PositionPoseSensorConfig Config_T;
@@ -64,13 +67,16 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
     AddHandler(pose_handler_);
 
     position_handler_.reset(
-        new PositionSensorHandler_T(*this, "", "position_sensor"));
+        new PositionSensorHandler_T(*this, "position_sensor", "position_sensor"));
     AddHandler(position_handler_);
 
     reconf_server_.reset(new ReconfigureServer(pnh));
     ReconfigureServer::CallbackType f = boost::bind(&this_T::Config, this, _1,
                                                     _2);
     reconf_server_->setCallback(f);
+
+    init_scale_srv_ = pnh.advertiseService("initialize_msf_scale",
+                                             &PositionPoseSensorManager::InitScale, this);
   }
   virtual ~PositionPoseSensorManager() {
   }
@@ -86,8 +92,9 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
 
   Config_T config_;
   ReconfigureServerPtr reconf_server_;  ///< Dynamic reconfigure server.
+  ros::ServiceServer init_scale_srv_;
 
-  /**
+    /**
    * \brief Dynamic reconfigure callback.
    */
   virtual void Config(Config_T &config, uint32_t level) {
@@ -121,6 +128,14 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
     }
   }
 
+  bool InitScale(sensor_fusion_comm::InitScale::Request &req,
+                 sensor_fusion_comm::InitScale::Response &res) {
+      ROS_INFO("Initialize filter with scale %f", req.scale);
+      Init(req.scale);
+      res.result = "Initialized scale";
+      return true;
+    }
+
   void Init(double scale) const {
     Eigen::Matrix<double, 3, 1> p, v, b_w, b_a, g, w_m, a_m, p_ic, p_vc, p_wv,
         p_ip, p_pos;
@@ -129,11 +144,12 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
 
     // init values
     g << 0, 0, 9.81;	/// Gravity.
-    b_w << 0, 0, 0;		/// Bias gyroscopes.
-    b_a << 0, 0, 0;		/// Bias accelerometer.
 
     v << 0, 0, 0;			/// Robot velocity (IMU centered).
     w_m << 0, 0, 0;		/// Initial angular velocity.
+
+    q.setIdentity();
+    p.setZero();
 
     q_wv.setIdentity();  // World-vision rotation drift.
     p_wv.setZero();      // World-vision position drift.
@@ -160,6 +176,17 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
           "No measurements received yet to initialize absolute position - using [0 0 0]");
 
     ros::NodeHandle pnh("~");
+    pnh.param("core/init/b_w/x", b_w[0], 0.0);
+    pnh.param("core/init/b_w/y", b_w[1], 0.0);
+    pnh.param("core/init/b_w/z", b_w[2], 0.0);
+
+    pnh.param("core/init/b_a/x", b_a[0], 0.0);
+    pnh.param("core/init/b_a/y", b_a[1], 0.0);
+    pnh.param("core/init/b_a/z", b_a[2], 0.0);
+
+    MSF_INFO_STREAM("b_a: " << b_a.transpose());
+    MSF_INFO_STREAM("b_w: " << b_w.transpose());
+
     pnh.param("pose_sensor/init/p_ic/x", p_ic[0], 0.0);
     pnh.param("pose_sensor/init/p_ic/y", p_ic[1], 0.0);
     pnh.param("pose_sensor/init/p_ic/z", p_ic[2], 0.0);
@@ -185,18 +212,17 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
     yawq.normalize();
 
     q = yawq;
-    q_wv = (q * q_ic * q_vc.conjugate()).conjugate();
+    q_wv = (q * q_ic * q_vc.conjugate()).conjugate(); // Wrong notation! q_wv is actually q_vw!
 
     MSF_WARN_STREAM("q " << STREAMQUAT(q));
     MSF_WARN_STREAM("q_wv " << STREAMQUAT(q_wv));
 
-    Eigen::Matrix<double, 3, 1> p_vision = q_wv.conjugate().toRotationMatrix()
-        * p_vc / scale - q.toRotationMatrix() * p_ic;
+    Eigen::Matrix<double, 3, 1> p_vision = q_wv.conjugate() * p_vc / scale - q * p_ic; // W_p_VI
 
     //TODO (slynen): what if there is no initial position measurement? Then we
     // have to shift vision-world later on, before applying the first position
     // measurement.
-    p = p_pos - q.toRotationMatrix() * p_ip;
+    p = p_pos - q * p_ip;
     p_wv = p - p_vision;  // Shift the vision frame so that it fits the position
     // measurement
 

--- a/msf_updates/src/position_pose_msf/position_pose_sensormanager.h
+++ b/msf_updates/src/position_pose_msf/position_pose_sensormanager.h
@@ -213,6 +213,7 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
 
     q = yawq;
     q_wv = (q * q_ic * q_vc.conjugate()).conjugate(); // Wrong notation! q_wv is actually q_vw!
+    // TODO: check if q_wv is used everywhere as q_vw & rename!
 
     MSF_WARN_STREAM("q " << STREAMQUAT(q));
     MSF_WARN_STREAM("q_wv " << STREAMQUAT(q_wv));
@@ -226,7 +227,7 @@ class PositionPoseSensorManager : public msf_core::MSF_SensorManagerROS<
     p_wv = p - p_vision;  // Shift the vision frame so that it fits the position
     // measurement
 
-    a_m = q.inverse() * g;			    /// Initial acceleration.
+    a_m = (q.inverse() * g) - b_a;			    /// De-biased initial acceleration.
 
     //TODO (slynen) Fix this.
     //we want z from vision (we did scale init), so:


### PR DESCRIPTION
Initialize biases from rosparam. 

These can be set before calling the init function or directly in the launch file (when already known)